### PR TITLE
Configuration generator rename, configs, cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Secrets in here
+config.yaml
+
+# The following was auto-generated for us by github:
+#########################
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+path.py
+PyYAML


### PR DESCRIPTION
I think that what I had was more of a PoC than a v1. I think this is a much more viable v1.

From the commit message:
- hybserv2ChanConfigs renamed to config_hybserv2
- config_hybserv2 now takes its db files and its channel configuration
  data as command-line flags
- code cleanups throughout for simplification and general readability

@stvstnfrd I'm clearly not in any rush, but want you to be aware of this. So please skim when you get a minute and hit the button whenever you're satisfied.

The configuration file that this takes is a YAML file in the form:

``` yaml
# comments are allowed
'Stanford/Demo/101': 
  - some_shared_passphrase_used_by_course_staff_here
  - [InstructorUsername1, InstructorUsername2, TA1]
'CMEx/999Q/Protein_synthesis_of_E_chromi': 
  - some_shared_passphrase_used_by_course_staff_here
  - [BobTBuilder, AGuestSpeaker, Instructor3, TA2]
```
